### PR TITLE
Collection-Level Masking Strategy Override and Erase After

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.5...main)
 
+### Changed
+
+- Add collection-level masking strategy overrides and support specifying one collection to be erased after another [#17](https://github.com/ethyca/fideslang/pull/17)
+
+
 ## [3.0.5](https://github.com/ethyca/fideslang/compare/3.0.4...3.0.5)
 
 ### Added
@@ -27,10 +32,6 @@ The types of changes are:
 ### Added
 
 - Adds mappings and new data use for special purposes 3 [#15](https://github.com/ethyca/fideslang/pull/15)
-
-### Changed
-
-- Add collection-level masking strategy overrides and support specifying one collection to be erased after another [#17](https://github.com/ethyca/fideslang/pull/17)
 
 
 ## [3.0.3](https://github.com/ethyca/fideslang/compare/3.0.2...3.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.3...main)
 
+### Changed
+
+- Add collection-level masking strategy overrides and support specifying one collection to be erased after another [#17](https://github.com/ethyca/fideslang/pull/17)
+
 
 ## [3.0.3](https://github.com/ethyca/fideslang/compare/3.0.2...3.0.3)
 - Add custom_request_field to FidesMeta [#13](https://github.com/ethyca/fideslang/pull/13)

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -62,8 +62,12 @@ meta_field = Field(
 )
 
 
-class MaskingStrategy(BaseModel):
-    strategy: str
+class MaskingStrategies(str, Enum):
+    delete = "delete"
+
+
+class MaskingStrategyOverride(BaseModel):
+    strategy: MaskingStrategies
 
 
 class FidesModel(BaseModel):
@@ -410,7 +414,6 @@ class FidesMeta(BaseModel):
         default=None,
         description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
     )
-    masking_strategy_override: Optional[MaskingStrategy] = None
 
     @field_validator("data_type")
     @classmethod
@@ -521,7 +524,7 @@ class CollectionMeta(BaseModel):
 
     after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
-    masking_strategy_override: Optional[MaskingStrategy] = None
+    masking_strategy_override: Optional[MaskingStrategyOverride] = None
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):
@@ -585,7 +588,6 @@ class DatasetMetadata(BaseModel):
 
     resource_id: Optional[str] = None
     after: Optional[List[FidesKey]] = None
-    masking_strategy_override: Optional[MaskingStrategy] = None
 
 
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -527,6 +527,7 @@ class CollectionMeta(BaseModel):
     """Collection-level specific annotations used for query traversal"""
 
     after: Optional[List[FidesCollectionKey]] = None
+    erase_after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
     masking_strategy_override: Optional[MaskingStrategyOverride] = None
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -62,6 +62,10 @@ meta_field = Field(
 )
 
 
+class MaskingStrategy(BaseModel):
+    strategy: str
+
+
 class FidesModel(BaseModel):
     """The base model for most top-level Fides objects."""
 
@@ -406,6 +410,7 @@ class FidesMeta(BaseModel):
         default=None,
         description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
     )
+    masking_strategy_override: Optional[MaskingStrategy] = None
 
     @field_validator("data_type")
     @classmethod
@@ -516,6 +521,7 @@ class CollectionMeta(BaseModel):
 
     after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
+    masking_strategy_override: Optional[MaskingStrategy] = None
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):
@@ -579,6 +585,7 @@ class DatasetMetadata(BaseModel):
 
     resource_id: Optional[str] = None
     after: Optional[List[FidesKey]] = None
+    masking_strategy_override: Optional[MaskingStrategy] = None
 
 
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -63,10 +63,14 @@ meta_field = Field(
 
 
 class MaskingStrategies(str, Enum):
-    delete = "delete"
+    """Possible options for masking strategy overrides"""
+
+    DELETE = "delete"
 
 
 class MaskingStrategyOverride(BaseModel):
+    """Overrides policy-level masking strategies."""
+
     strategy: MaskingStrategies
 
 

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -791,12 +791,20 @@ class TestCollectionMeta:
     def test_valid_collection_key(self):
         CollectionMeta(after=[FidesCollectionKey("test_dataset.test_collection")])
 
-    def test_(self):
+    def test_delete_masking_strategy(self):
         meta = CollectionMeta(masking_strategy_override={"strategy": "delete"})
 
         assert meta.masking_strategy_override == MaskingStrategyOverride(
             strategy=MaskingStrategies.DELETE
         )
+
+    def test_erase_after(self):
+        meta = CollectionMeta(
+            erase_after=[FidesCollectionKey("test_dataset.test_collection")]
+        )
+
+        assert meta.erase_after == [FidesCollectionKey("test_dataset.test_collection")]
+
 
 
 class TestAnyUrlString:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -15,6 +15,8 @@ from fideslang.models import (
     FidesDatasetReference,
     FidesMeta,
     FidesModel,
+    MaskingStrategies,
+    MaskingStrategyOverride,
     Policy,
     PolicyRule,
     PrivacyDeclaration,
@@ -642,7 +644,7 @@ class TestValidateFidesopsMeta:
             length=None,
             return_all_elements=None,
             read_only=None,
-            custom_request_field="site_id"
+            custom_request_field="site_id",
         )
 
     def test_specify_both_fidesops_meta_and_fides_meta(self):
@@ -788,6 +790,13 @@ class TestCollectionMeta:
 
     def test_valid_collection_key(self):
         CollectionMeta(after=[FidesCollectionKey("test_dataset.test_collection")])
+
+    def test_(self):
+        meta = CollectionMeta(masking_strategy_override={"strategy": "delete"})
+
+        assert meta.masking_strategy_override == MaskingStrategyOverride(
+            strategy=MaskingStrategies.delete
+        )
 
 
 class TestAnyUrlString:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -795,7 +795,7 @@ class TestCollectionMeta:
         meta = CollectionMeta(masking_strategy_override={"strategy": "delete"})
 
         assert meta.masking_strategy_override == MaskingStrategyOverride(
-            strategy=MaskingStrategies.delete
+            strategy=MaskingStrategies.DELETE
         )
 
 


### PR DESCRIPTION
Closes #PROD-2743


### Description Of Changes

Define two things on Collection Meta to support erasure operations at the row level for database connectors.

Defines a masking strategy override under Collection Meta that will override Policy-based masking strategies if applicable and supported.  Further configuration options may be supported in the future, but for now, we just have the strategy name.

```yaml
dataset:
  - fides_key: postgres_example_test_dataset
    name: Postgres Example Test Dataset
    description: Example of a Postgres dataset containing a variety of related tables like customers, products, addresses, etc.
    collections:
      - name: address
        fides_meta:
          masking_strategy_override:
            strategy: delete
```

Allow `erase_after` to be specified:
```yaml
      - name: customer
        fides_meta:
          erase_after:
            - bigquery_example_test_dataset.address
```

### Code Changes

* [ ] Add new `masking_strategy_override` under collection meta 
* [ ] Add new `erase_after` under collection meta, meant to be specified as a list of dataset.collection references.  This was supported for saas connectors but not database connectors directly

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
