### PR TITLE
HA-399 deprecate cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The types of changes are:
 ## [3.1.0](https://github.com/ethyca/fideslang/compare/3.0.9...3.1.0)
 
 ### Deprecated
-- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#199](https://github.com/IABTechLab/fideslang/pull/199)
+- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#199](https://github.com/ethyca/fideslang/pull/27)
 
 
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.1.0...main)
+
+
+## [3.1.0](https://github.com/ethyca/fideslang/compare/3.0.9...3.1.0)
 
 ### Deprecated
 - Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#199](https://github.com/IABTechLab/fideslang/pull/199)
+
 
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
 
+### Deprecated
+- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#198](https://github.com/IABTechLab/fideslang/pull/198)
+
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
 
 ### Deprecated
-- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#198](https://github.com/IABTechLab/fideslang/pull/198)
+- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#199](https://github.com/IABTechLab/fideslang/pull/199)
 
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -798,7 +798,7 @@ class Policy(FidesModel):
     _sort_rules: classmethod = field_validator("rules")(sort_list_objects_by_name)  # type: ignore[assignment]
 
 
-class PrivacyDeclaration(BaseModel):
+class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
     """
     The PrivacyDeclaration resource model.
 
@@ -871,7 +871,7 @@ class PrivacyDeclaration(BaseModel):
         default_factory=list,
         description="The categories of personal data that this system shares with third parties.",
     )
-    cookies: Optional[Any] = Field(
+    cookies: Optional[Any] = Field(  # type: ignore
         default=None,
         description="Deprecated, do not use.",
         deprecated=True,
@@ -880,7 +880,7 @@ class PrivacyDeclaration(BaseModel):
 
     @field_validator("cookies")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:
+    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:  # type: ignore
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
@@ -971,7 +971,7 @@ class DataFlow(BaseModel):
         return value
 
 
-class System(FidesModel):
+class System(FidesModel):  # type: ignore[misc]
     """
     The System resource model.
 
@@ -1099,7 +1099,7 @@ class System(FidesModel):
         default=None,
         description="A URL that points to the system's publicly accessible legitimate interest disclosure.",
     )
-    cookies: Optional[Any] = Field(  # mypy: ignore[valid-type]
+    cookies: Optional[Any] = Field(  # type: ignore
         default=None,
         description="Deprecated, do not use.",
         deprecated=True,
@@ -1107,9 +1107,7 @@ class System(FidesModel):
 
     @field_validator("cookies")
     @classmethod
-    def validate_cookies(
-        cls, value: Optional[Any]  # type: ignore[misc]
-    ) -> Optional[Any]:
+    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:  # type: ignore
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1100,11 +1100,6 @@ class System(FidesModel):  # type: ignore[misc]
         default=None,
         description="A URL that points to the system's publicly accessible legitimate interest disclosure.",
     )
-    cookies: Optional[Any] = Field(  # type: ignore
-        default=None,
-        description="Deprecated, do not use.",
-        deprecated=True,
-    )
 
     @field_validator("cookies")
     @classmethod

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -872,7 +872,7 @@ class PrivacyDeclaration(BaseModel):
         description="The categories of personal data that this system shares with third parties.",
     )
     cookies: Optional[Any] = Field(
-        default_factory=None,
+        default=None,
         description="Deprecated, do not use.",
         deprecated=True,
     )
@@ -1099,15 +1099,17 @@ class System(FidesModel):
         default=None,
         description="A URL that points to the system's publicly accessible legitimate interest disclosure.",
     )
-    cookies: Optional[Any] = Field(
-        default_factory=None,
+    cookies: Optional[Any] = Field(  # mypy: ignore[valid-type]
+        default=None,
         description="Deprecated, do not use.",
         deprecated=True,
     )
 
     @field_validator("cookies")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:
+    def validate_cookies(
+        cls, value: Optional[Any]  # type: ignore[misc]
+    ) -> Optional[Any]:
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -879,7 +879,7 @@ class PrivacyDeclaration(BaseModel):
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if type(values) == dict:
+        if isinstance(values, dict):
             keys = values.keys()
         else:
             keys = vars(values).keys()
@@ -1108,7 +1108,7 @@ class System(FidesModel):
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if type(values) == dict:
+        if isinstance(values, dict):
             keys = values.keys()
         else:
             keys = vars(values).keys()

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -875,15 +875,21 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
 
     @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if "cookies" in values and values["cookies"] is not None:
+        if type(values) == dict:
+            keys = values.keys()
+        else:
+            keys = vars(values).keys()
+        if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
-        return values
+            return values
+        else:
+            return values
 
 
 class SystemMetadata(BaseModel):
@@ -1099,15 +1105,21 @@ class System(FidesModel):  # type: ignore[misc]
 
     @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if "cookies" in values and values["cookies"] is not None:
+        if type(values) == dict:
+            keys = values.keys()
+        else:
+            keys = vars(values).keys()
+        if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
-        return values
+            return values
+        else:
+            return values
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]
         sort_list_objects_by_name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -798,6 +798,23 @@ class Policy(FidesModel):
     _sort_rules: classmethod = field_validator("rules")(sort_list_objects_by_name)  # type: ignore[assignment]
 
 
+def validate_deprecated_cookies(values: Dict[str, Any] | Any) -> None:
+    """
+    Shared function to validate that the `cookies` field is deprecated and warn that it should not be used.
+    """
+    if isinstance(values, dict):
+        keys = values.keys()
+    else:
+        try:
+            keys = vars(values).keys()
+        except Exception:  # pylint: disable=broad-except
+            keys = {}  # type: ignore[assignment]
+    if "cookies" in keys:
+        warn(
+            "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
+        )
+
+
 class PrivacyDeclaration(BaseModel):
     """
     The PrivacyDeclaration resource model.
@@ -871,7 +888,6 @@ class PrivacyDeclaration(BaseModel):
         default_factory=list,
         description="The categories of personal data that this system shares with third parties.",
     )
-    model_config = ConfigDict(from_attributes=True)
 
     @model_validator(mode="before")
     @classmethod
@@ -879,19 +895,10 @@ class PrivacyDeclaration(BaseModel):
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if isinstance(values, dict):
-            keys = values.keys()
-        else:
-            try:
-                keys = vars(values).keys()
-            except Exception:  # pylint: disable=broad-except
-                keys = {}  # type: ignore[assignment]
-        if "cookies" in keys:
-            warn(
-                "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
-            )
-
+        validate_deprecated_cookies(values)
         return values
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class SystemMetadata(BaseModel):
@@ -1111,18 +1118,7 @@ class System(FidesModel):
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if isinstance(values, dict):
-            keys = values.keys()
-        else:
-            try:
-                keys = vars(values).keys()
-            except Exception:  # pylint: disable=broad-except
-                keys = {}  # type: ignore[assignment]
-        if "cookies" in keys:
-            warn(
-                "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
-            )
-
+        validate_deprecated_cookies(values)
         return values
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -885,7 +885,9 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
         if value is not None:
-            warn("The 'cookies' field is deprecated and should not be used.")
+            warn(
+                "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
+            )
 
 
 class SystemMetadata(BaseModel):
@@ -1111,7 +1113,9 @@ class System(FidesModel):  # type: ignore[misc]
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
         if value is not None:
-            warn("The 'cookies' field is deprecated and should not be used.")
+            warn(
+                "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
+            )
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]
         sort_list_objects_by_name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -882,7 +882,10 @@ class PrivacyDeclaration(BaseModel):
         if isinstance(values, dict):
             keys = values.keys()
         else:
-            keys = vars(values).keys()
+            try:
+                keys = vars(values).keys()
+            except Exception:
+                keys = []
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
@@ -1111,7 +1114,10 @@ class System(FidesModel):
         if isinstance(values, dict):
             keys = values.keys()
         else:
-            keys = vars(values).keys()
+            try:
+                keys = vars(values).keys()
+            except Exception:
+                keys = []
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -884,7 +884,7 @@ class PrivacyDeclaration(BaseModel):
         else:
             try:
                 keys = vars(values).keys()
-            except (Exception,):  # type: ignore[misc]
+            except Exception:  # pylint: disable=broad-except
                 keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(
@@ -1116,7 +1116,7 @@ class System(FidesModel):
         else:
             try:
                 keys = vars(values).keys()
-            except (Exception,):
+            except Exception:  # pylint: disable=broad-except
                 keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -798,7 +798,7 @@ class Policy(FidesModel):
     _sort_rules: classmethod = field_validator("rules")(sort_list_objects_by_name)  # type: ignore[assignment]
 
 
-def validate_deprecated_cookies(values: Dict[str, Any] | Any) -> None:
+def validate_deprecated_cookies(values: Dict[str, Any] | Any) -> None:  # type: ignore[misc]
     """
     Shared function to validate that the `cookies` field is deprecated and warn that it should not be used.
     """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -880,13 +880,12 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
 
     @field_validator("cookies")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:  # type: ignore
+    def validate_cookies(cls, value: Optional[Any]) -> None:  # type: ignore
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
         if value is not None:
             warn("The 'cookies' field is deprecated and should not be used.")
-        return None
 
 
 class SystemMetadata(BaseModel):
@@ -1107,13 +1106,12 @@ class System(FidesModel):  # type: ignore[misc]
 
     @field_validator("cookies")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:  # type: ignore
+    def validate_cookies(cls, value: Optional[Any]) -> None:  # type: ignore
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
         if value is not None:
             warn("The 'cookies' field is deprecated and should not be used.")
-        return None
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]
         sort_list_objects_by_name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -878,16 +878,17 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
     )
     model_config = ConfigDict(from_attributes=True)
 
-    @field_validator("cookies")
+    @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> None:  # type: ignore
+    def validate_cookies(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if value is not None:
+        if "cookies" in values and values["cookies"] is not None:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
+        return values
 
 
 class SystemMetadata(BaseModel):
@@ -1101,16 +1102,17 @@ class System(FidesModel):  # type: ignore[misc]
         description="A URL that points to the system's publicly accessible legitimate interest disclosure.",
     )
 
-    @field_validator("cookies")
+    @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, value: Optional[Any]) -> None:  # type: ignore
+    def validate_cookies(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
-        if value is not None:
+        if "cookies" in values and values["cookies"] is not None:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
+        return values
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]
         sort_list_objects_by_name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -871,11 +871,6 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
         default_factory=list,
         description="The categories of personal data that this system shares with third parties.",
     )
-    cookies: Optional[Any] = Field(  # type: ignore
-        default=None,
-        description="Deprecated, do not use.",
-        deprecated=True,
-    )
     model_config = ConfigDict(from_attributes=True)
 
     @model_validator(mode="before")

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -884,7 +884,7 @@ class PrivacyDeclaration(BaseModel):
         else:
             try:
                 keys = vars(values).keys()
-            except Exception:  # type: ignore[misc]
+            except (Exception,):  # type: ignore[misc]
                 keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(
@@ -1116,7 +1116,7 @@ class System(FidesModel):
         else:
             try:
                 keys = vars(values).keys()
-            except Exception:  # type: ignore[misc]
+            except (Exception,):
                 keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -885,7 +885,7 @@ class PrivacyDeclaration(BaseModel):
             try:
                 keys = vars(values).keys()
             except Exception:
-                keys = []
+                keys = {}
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
@@ -1117,7 +1117,7 @@ class System(FidesModel):
             try:
                 keys = vars(values).keys()
             except Exception:
-                keys = []
+                keys = {}
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -798,7 +798,7 @@ class Policy(FidesModel):
     _sort_rules: classmethod = field_validator("rules")(sort_list_objects_by_name)  # type: ignore[assignment]
 
 
-class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
+class PrivacyDeclaration(BaseModel):
     """
     The PrivacyDeclaration resource model.
 
@@ -875,7 +875,7 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
 
     @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:
+    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:  # type: ignore[misc]
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
@@ -887,9 +887,8 @@ class PrivacyDeclaration(BaseModel):  # type: ignore[misc]
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
-            return values
-        else:
-            return values
+
+        return values
 
 
 class SystemMetadata(BaseModel):
@@ -974,7 +973,7 @@ class DataFlow(BaseModel):
         return value
 
 
-class System(FidesModel):  # type: ignore[misc]
+class System(FidesModel):
     """
     The System resource model.
 
@@ -1105,7 +1104,7 @@ class System(FidesModel):  # type: ignore[misc]
 
     @model_validator(mode="before")
     @classmethod
-    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:
+    def validate_cookies(cls, values: Dict[str, Any] | Any) -> Dict[str, Any]:  # type: ignore[misc]
         """
         Validate that the `cookies` field is deprecated and warn that it should not be used.
         """
@@ -1117,9 +1116,8 @@ class System(FidesModel):  # type: ignore[misc]
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
             )
-            return values
-        else:
-            return values
+
+        return values
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]
         sort_list_objects_by_name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -884,8 +884,8 @@ class PrivacyDeclaration(BaseModel):
         else:
             try:
                 keys = vars(values).keys()
-            except Exception:
-                keys = {}
+            except Exception:  # type: ignore[misc]
+                keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."
@@ -1116,8 +1116,8 @@ class System(FidesModel):
         else:
             try:
                 keys = vars(values).keys()
-            except Exception:
-                keys = {}
+            except Exception:  # type: ignore[misc]
+                keys = {}  # type: ignore[assignment]
         if "cookies" in keys:
             warn(
                 "The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored."

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1105,9 +1105,14 @@ class System(FidesModel):
         deprecated=True,
     )
 
-    @field_validator("cookies", pre=True, always=True)
+    @field_validator("cookies")
     @classmethod
-    def set_cookies_to_none(cls, Optional[Any]) -> Optional[Any]:
+    def validate_cookies(cls, value: Optional[Any]) -> Optional[Any]:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        if value is not None:
+            warn("The 'cookies' field is deprecated and should not be used.")
         return None
 
     _sort_privacy_declarations: classmethod = field_validator("privacy_declarations")(  # type: ignore[assignment]

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from typing import Annotated, Dict, List, Optional, Union, Any
+from warnings import warn
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -284,12 +285,23 @@ class DataCategory(FidesModel, DefaultModel):
 
 
 class Cookies(BaseModel):
-    """The Cookies resource model"""
+    """
+    DEPRECATED.
+    The Cookies resource model
+    """
 
     name: str
     path: Optional[str] = None
     domain: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def validate_cookies(self, _: ValidationInfo) -> Cookies:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        warn("The 'cookies' field is deprecated and should not be used.")
+        return self
 
 
 class DataSubjectRights(BaseModel):
@@ -881,9 +893,21 @@ class PrivacyDeclaration(BaseModel):
     )
     cookies: Optional[List[Cookies]] = Field(
         default=None,
-        description="Cookies associated with this data use to deliver services and functionality",
+        description="DEPRECATED. Cookies associated with this data use to deliver services and functionality",
     )
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("cookies")
+    @classmethod
+    def validate_cookies(
+        cls, value: Optional[List[Cookies]]
+    ) -> Optional[List[Cookies]]:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        if value is not None:
+            warn("The 'cookies' field is deprecated and should not be used.")
+        return value
 
 
 class SystemMetadata(BaseModel):
@@ -1133,6 +1157,18 @@ class System(FidesModel):
                         ], f"PrivacyDeclaration '{privacy_declaration.name}' defines {direction} with '{fides_key}' and is applied to the System '{system}', which does not itself define {direction} with that resource."
 
         return self
+
+    @field_validator("cookies")
+    @classmethod
+    def validate_cookies(
+        cls, value: Optional[List[Cookies]]
+    ) -> Optional[List[Cookies]]:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        if value is not None:
+            warn("The 'cookies' field is deprecated and should not be used.")
+        return value
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -5,7 +5,6 @@ from pytest import mark, raises
 from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
 from fideslang.models import (
     ContactDetails,
-    Cookies,
     DataResponsibilityTitle,
     DatasetCollection,
     DatasetField,
@@ -175,7 +174,7 @@ class TestSystem:
                 data_shared_with_third_parties=False,
                 third_parties=None,
                 shared_categories=[],
-                cookies=[Cookies(name="test_cookie", path="/", domain="example.com")],
+                cookies=None,
             )
         ]
 

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -133,6 +133,7 @@ class TestSystem:
             system_type="SYSTEM",
             tags=["some", "tags"],
         )
+
         assert system.name == "Test System"
         assert system.fides_key == "test_system"
         assert system.description == "Test Policy"
@@ -152,7 +153,7 @@ class TestSystem:
         ]
         assert system.meta == {"some": "meta stuff"}
         assert system.organization_fides_key == "1"
-        assert system.cookies == [Cookies(name="test_cookie", path=None, domain=None)]
+        assert system.cookies == None
         assert system.system_type == "SYSTEM"
         assert system.tags == ["some", "tags"]
         assert system.privacy_declarations == [

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pytest import mark, raises
+from pytest import mark, raises, warns
 
 from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
 from fideslang.models import (
@@ -469,6 +469,30 @@ class TestSystem:
         )
         print(f"dumped={system.model_dump()}")
         assert "cookies" not in system.model_dump()
+
+    def test_system_cookies_warning(self) -> None:
+
+        with warns(
+            UserWarning,
+            match="The 'cookies' field is deprecated and should not be used. Any value given as this field will be ignored.",
+        ):
+            System(
+                description="Test Policy",
+                fides_key="test_system",
+                name="Test System",
+                organization_fides_key="1",
+                privacy_declarations=[
+                    PrivacyDeclaration(
+                        data_categories=[],
+                        data_subjects=[],
+                        data_use="provide",
+                        name="declaration-name",
+                        cookies=[{"name": "test_cookie"}],
+                    )
+                ],
+                system_type="SYSTEM",
+                cookies=[{"name": "test_cookie"}],
+            )
 
     def test_flexible_legal_basis_default(self):
         pd = PrivacyDeclaration(

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -115,7 +115,6 @@ class TestSystem:
             meta={"some": "meta stuff"},
             name="Test System",
             organization_fides_key="1",
-            cookies=[{"name": "test_cookie"}],
             privacy_declarations=[
                 PrivacyDeclaration(
                     data_categories=[],
@@ -124,9 +123,6 @@ class TestSystem:
                     egress=["test_system_2"],
                     ingress=["test_system_3"],
                     name="declaration-name",
-                    cookies=[
-                        {"name": "test_cookie", "path": "/", "domain": "example.com"}
-                    ],
                 )
             ],
             system_type="SYSTEM",
@@ -152,9 +148,6 @@ class TestSystem:
         ]
         assert system.meta == {"some": "meta stuff"}
         assert system.organization_fides_key == "1"
-        assert (
-            system.cookies == None
-        ), "Cookies are deprecated and should be ignored on the model"
         assert system.system_type == "SYSTEM"
         assert system.tags == ["some", "tags"]
         assert system.privacy_declarations == [
@@ -176,9 +169,9 @@ class TestSystem:
                 data_shared_with_third_parties=False,
                 third_parties=None,
                 shared_categories=[],
-                cookies=None,  # Cookies are deprecated and should be ignored on the model
             )
         ]
+        assert "cookies" not in system.model_dump()
 
     def test_system_valid_nested_meta(self) -> None:
         system = System(
@@ -444,9 +437,6 @@ class TestSystem:
                     third_parties="advertising; marketing",
                     shared_categories=[],
                     flexible_legal_basis_for_processing=True,
-                    cookies=[
-                        {"name": "ANON_ID", "path": "/", "domain": "tribalfusion.com"}
-                    ],
                 )
             ],
             vendor_id="gvl.1",
@@ -474,13 +464,6 @@ class TestSystem:
             uses_non_cookie_access=True,
             legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
             previous_vendor_id="gacp.10",
-            cookies=[
-                {
-                    "name": "COOKIE_ID_EXAMPLE",
-                    "path": "/",
-                    "domain": "example.com/cookie",
-                }
-            ],
         )
         print(f"dumped={system.model_dump()}")
 

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -169,6 +169,7 @@ class TestSystem:
                 data_shared_with_third_parties=False,
                 third_parties=None,
                 shared_categories=[],
+                cookies=[{"name": "test_cookie"}],
             )
         ]
         assert "cookies" not in system.model_dump()
@@ -460,12 +461,14 @@ class TestSystem:
             data_security_practices=None,
             cookie_max_age_seconds="31536000",
             uses_cookies=True,
+            cookies=[{"name": "test_cookie"}],
             cookie_refresh=True,
             uses_non_cookie_access=True,
             legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
             previous_vendor_id="gacp.10",
         )
         print(f"dumped={system.model_dump()}")
+        assert "cookies" not in system.model_dump()
 
     def test_flexible_legal_basis_default(self):
         pd = PrivacyDeclaration(

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -152,7 +152,9 @@ class TestSystem:
         ]
         assert system.meta == {"some": "meta stuff"}
         assert system.organization_fides_key == "1"
-        assert system.cookies == None
+        assert (
+            system.cookies == None
+        ), "Cookies are deprecated and should be ignored on the model"
         assert system.system_type == "SYSTEM"
         assert system.tags == ["some", "tags"]
         assert system.privacy_declarations == [
@@ -174,7 +176,7 @@ class TestSystem:
                 data_shared_with_third_parties=False,
                 third_parties=None,
                 shared_categories=[],
-                cookies=None,
+                cookies=None,  # Cookies are deprecated and should be ignored on the model
             )
         ]
 


### PR DESCRIPTION
Deprecating the formal `Cookies` model. Instead, cookies are now represented as `Asset`s ([defined in Fides](https://github.com/ethyca/fides/pull/5616/files#diff-cba846ca147fcc0c50f7d457b7e2c4c146cec0e7c553a72a2702f90526b48600)) of type `cookie`.

Part of HA-399

### Description Of Changes

Add validators to the `Cookies` model and each model that uses a `.cookies` property warning of deprecation

### Code Changes

* [x] remove `cookies` properties
* [x] remove `Cookies` model
* [x] add validators to warn for deprecation when `cookies` property is used

### Steps to Confirm

* [x] see comment [here](https://github.com/ethyca/fideslang/pull/27#discussion_r2018787403)
* [x] testing done on associated fides PR: https://github.com/ethyca/fides/pull/5776

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
