### PR TITLE
license fix IV: pin versions in github actions

### DIFF
--- a/.github/workflows/publish_package.yaml
+++ b/.github/workflows/publish_package.yaml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Twine
-        run: pip install twine
+        run: |
+          pip install twine==6.1.0
+          pip install packaging==24.2
 
       - name: Build Distributions
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ dynamic = ["dependencies", "version"]
 readme = "README.md"
 requires-python = ">=3.9, <4"
 authors = [{ name = "Ethyca, Inc.", email = "fidesteam@ethyca.com" }]
-license = { text = "Apache License 2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Fix formatting in license field for pyproject and pin versions of build tools in github actions