### PR TITLE
Adding redact fides meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.1.0...main)
 
+### Added
+- Added `fides_meta.redact` to datasets, collections, and fields [#35](https://github.com/ethyca/fideslang/pull/35)
+
+## [3.1.1](https://github.com/ethyca/fideslang/compare/3.1.0...3.1.1)
+
 ### Changed
 - Updated the type for `CollectionMeta.partitioning` to allow a list of dicts [#34](https://github.com/ethyca/fideslang/pull/34)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Dict, List, Optional, Union, Literal
 from warnings import warn
 
 from packaging.version import InvalidVersion, Version
@@ -421,6 +421,10 @@ class FidesMeta(BaseModel):
         default=None,
         description="Optionally specify a masking strategy override for this field.",
     )
+    redact: Optional[Literal["name"]] = Field(
+        default=None,
+        description="Specify 'name' to indicate the field name should be redacted.",
+    )
 
     @field_validator("data_type")
     @classmethod
@@ -532,6 +536,10 @@ class CollectionMeta(BaseModel):
     # partitioning metadata is kept open-ended as it is an experimental feature -
     # more strictly defined metadata structures will be supported in the future
     partitioning: Optional[Union[Dict, List[Dict]]] = None
+    redact: Optional[Literal["name"]] = Field(
+        default=None,
+        description="Specify 'name' to indicate the collection name should be redacted.",
+    )
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):
@@ -596,6 +604,10 @@ class DatasetMetadata(BaseModel):
     resource_id: Optional[str] = None
     after: Optional[List[FidesKey]] = None
     namespace: Optional[Dict] = None
+    redact: Optional[Literal["name"]] = Field(
+        default=None,
+        description="Specify 'name' to indicate the dataset name should be redacted.",
+    )
 
 
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):


### PR DESCRIPTION
### Description Of Changes

Adds `fides_meta.redact` to datasets, collection, and fields. This new field will only contain the literal value of `name` for now.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
